### PR TITLE
Make `highcharts-chart.component.ts` compatible with strict compilation (noImplicitAny, noImplicitThis, etc.)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,15 +39,16 @@
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
     "core-js": "^2.4.1",
-    "rxjs": "^5.5.6",
-    "zone.js": "^0.8.19",
     "highcharts": "^6.0.7",
-    "highcharts-custom-events": "^2.0.20"
+    "highcharts-custom-events": "^2.0.20",
+    "rxjs": "^5.5.6",
+    "zone.js": "^0.8.19"
   },
   "devDependencies": {
     "@angular/cli": "~1.7.3",
     "@angular/compiler-cli": "^5.2.0",
     "@angular/language-service": "^5.2.0",
+    "@types/highcharts": "^5.0.23",
     "@types/jasmine": "~2.8.3",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,11 @@
-declare var require: any
+declare var require: any;
 
 import { Component } from '@angular/core';
 
 import * as Highcharts from 'highcharts/highstock';
-import * as HC_map from 'highcharts/modules/map';
-import * as HC_exporting from 'highcharts/modules/exporting';
-import * as HC_ce from 'highcharts-custom-events';
+const HC_map = require('highcharts/modules/map');
+const HC_exporting = require('highcharts/modules/exporting');
+const HC_ce = require('highcharts-custom-events');
 
 HC_map(Highcharts);
 require('../../js/worldmap')(Highcharts);
@@ -46,22 +46,22 @@ export class AppComponent {
   optFromInput = JSON.parse(this.optFromInputString);
   updateFromInput = false;
 
-  updateInputChart = function() {
+  updateInputChart() {
     this.optFromInput = JSON.parse(this.optFromInputString);
-  };
+  }
 
-  seriesTypes = {
+  seriesTypes: {[key: string]: string} = {
     line: 'column',
     column: 'scatter',
     scatter: 'spline',
     spline: 'line'
   };
 
-  toggleSeriesType = function(index = 0) {
+  toggleSeriesType(index = 0) {
     this.optFromInput.series[index].type = this.seriesTypes[this.optFromInput.series[index].type];
     // nested change - must trigger update
     this.updateFromInput = true;
-  };
+  }
 
   //----------------------------------------------------------------------
   // Demo #2
@@ -72,7 +72,7 @@ export class AppComponent {
   chartTitle = 'My chart'; // for init - change through titleChange
 
   // change in all places
-  titleChange = function(event) {
+  titleChange(event: any) {
     var v = event;
     this.chartTitle = v;
     this.charts.forEach((el) => {
@@ -106,7 +106,7 @@ export class AppComponent {
         ]
       }]
     },
-  	hcCallback: (chart) => { console.log('some variables: ', Highcharts, chart, this.charts); }
+  	hcCallback: (chart: Highcharts.Chart) => { console.log('some variables: ', Highcharts, chart, this.charts); }
   }, {
   	hcOptions: {
       title: { text: this.chartTitle },

--- a/src/app/highcharts-chart.component.ts
+++ b/src/app/highcharts-chart.component.ts
@@ -4,7 +4,6 @@ import { Component, ElementRef, EventEmitter, Input, Output } from '@angular/cor
   selector: 'highcharts-chart',
   template: ''
 })
-
 export class HighchartsChartComponent {
   constructor(private el: ElementRef) { };
 
@@ -14,21 +13,21 @@ export class HighchartsChartComponent {
   @Input() callbackFunction: any;
   optionsValue: any;
   @Input()
-  set options(val) {
+  set options(val: any) {
     this.optionsValue = val;
     this.updateOrCreateChart();
   }
   updateValue = false;
   @Output() updateChange = new EventEmitter(true);
-  @Input() set update(val) {
+  @Input() set update(val: boolean) {
     if (val) {
       this.updateOrCreateChart();
       this.updateChange.emit(false); // clear the flag after update
     }
   }
   @Input() oneToOne: boolean; //#20
-  
-  updateOrCreateChart = function () {
+
+  updateOrCreateChart() {
     if (this.chart && this.chart.update) {
       this.chart.update(this.optionsValue, true, this.oneToOne || false);
     } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    
     "allowJs": false,
-
     "outDir": "./dist/out-tsc",
     "baseUrl": "src",
     "sourceMap": true,
@@ -11,6 +9,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "strict": true,
     "target": "es5",
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
This is to allow users to compile the module with the `"strict": true` setting in their tsconfig.json (which enables `noImplicitAny`, `noImplicitThis`, etc)

I'll see if I can work on a build to .js tomorrow so that people don't have to worry about this though, and so that the tsconfig "include" hack is no longer needed.