### PR TITLE
Upgrade minor version of TypeScript fixing build

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "standard-version": "^4.4.0",
     "ts-node": "~4.1.0",
     "tsickle": ">=0.25.5",
-    "tslib": "^1.7.1",
-    "tslint": "^5.10.0",
-    "typescript": "~2.7.2"
+    "tslib": "^1.9.3",
+    "tslint": "^5.11.0",
+    "typescript": "~2.8.0"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -82,7 +82,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [
@@ -104,9 +103,6 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true,
-    "no-access-missing-member": true,
-    "templates-use-public": true,
-    "invoke-injectable": true
+    "directive-class-suffix": true
   }
 }


### PR DESCRIPTION
- TypeScript update
- fix TSLint deprecation warnings
- redundant `typeof-compare` rule removed

Thanks!

Error removed:
```bash
Building Angular Package
Building entry point 'highcharts-angular'
Rendering Stylesheets
Rendering Templates
Compiling TypeScript sources through ngc

BUILD ERROR
node_modules/@types/jasmine/index.d.ts(138,47): error TS1005: ';' expected.
node_modules/@types/jasmine/index.d.ts(138,90): error TS1005: '(' expected.
node_modules/@types/jasmine/index.d.ts(138,104): error TS1005: ']' expected.
node_modules/@types/jasmine/index.d.ts(138,112): error TS1005: ',' expected.
node_modules/@types/jasmine/index.d.ts(138,113): error TS1136: Property assignment expected.
node_modules/@types/jasmine/index.d.ts(138,121): error TS1005: ')' expected.
node_modules/@types/jasmine/index.d.ts(138,147): error TS1005: '(' expected.
node_modules/@types/jasmine/index.d.ts(138,162): error TS1005: ']' expected.
node_modules/@types/jasmine/index.d.ts(138,163): error TS1005: ',' expected.
....
```

TSLint warnings removed:

```
typeof-compare is deprecated. Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant.

Could not find implementations for the following rules specified in the configuration:
    no-access-missing-member
    templates-use-public
    invoke-injectable
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
```