### PR TITLE
Allow using custom Highcharts bundles by importing Highcharts as "type only" import

### DIFF
--- a/highcharts-angular/package.json
+++ b/highcharts-angular/package.json
@@ -21,7 +21,8 @@
   "peerDependencies": {
     "@angular/common": ">=6.0.0",
     "@angular/core": ">=6.0.0",
-    "highcharts": ">=6.0.0"
+    "highcharts": ">=6.0.0",
+    "typescript": ">=3.8.2"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/highcharts-angular/src/lib/highcharts-chart.component.ts
+++ b/highcharts-angular/src/lib/highcharts-chart.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, OnDestroy, Output, NgZone, OnChanges, SimpleChanges } from '@angular/core';
-import * as Highcharts from 'highcharts';
+import type * as Highcharts from 'highcharts';
 
 @Component({
   selector: 'highcharts-chart',


### PR DESCRIPTION
Fixes issue #278 . `highcharts-angular` should not force full `highcharts` library to be included.