### PR TITLE
Fix emit chart instance on destroy

### DIFF
--- a/highcharts-angular/src/lib/highcharts-chart.component.ts
+++ b/highcharts-angular/src/lib/highcharts-chart.component.ts
@@ -64,6 +64,9 @@ export class HighchartsChartComponent implements OnDestroy, OnChanges {
     if (this.chart) {  // #56
       this.chart.destroy();
       this.chart = null;
+
+      // emit chart instance on destroy
+      this.chartInstance.emit(this.chart);
     }
   }
 }


### PR DESCRIPTION
Fix #365, the chat instance was not emitted on the `ngOnDestroy`.