### PR TITLE
`provideHighcharts()` cannot be used in components

### DIFF
--- a/highcharts-angular/src/lib/highcharts-chart.provider.ts
+++ b/highcharts-angular/src/lib/highcharts-chart.provider.ts
@@ -22,7 +22,7 @@ export function providePartialHighcharts(config: PartialHighchartsConfig): Provi
   return { provide: HIGHCHARTS_CONFIG, useValue: config };
 }
 
-export function provideHighcharts(config: HighchartsConfig = {}): EnvironmentProviders[] {
+export function provideHighcharts(config: HighchartsConfig = {}): EnvironmentProviders {
   const providers: EnvironmentProviders[] = [
     provideHighchartsInstance(config.instance),
     provideHighchartsRootModules(config.modules ?? emptyModuleFactoryFunction)
@@ -30,5 +30,5 @@ export function provideHighcharts(config: HighchartsConfig = {}): EnvironmentPro
   if (config.options) {
     providers.push(provideHighchartsOptions(config.options));
   }
-  return providers;
+  return makeEnvironmentProviders(providers);
 }


### PR DESCRIPTION
Because `provideHighcharts()` is using environnement providers, it must itself be an environment providers to prevent it being used in a component and throwing NG0207 errors at runtime.

Relates to https://github.com/highcharts/highcharts-angular/issues/405#issuecomment-2981677058