### PR TITLE
#432 - fix options change not updating the chart

### DIFF
--- a/highcharts-angular/src/lib/highcharts-chart.directive.ts
+++ b/highcharts-angular/src/lib/highcharts-chart.directive.ts
@@ -97,6 +97,7 @@ export class HighchartsChartDirective {
       // Wait for the chart to be created
       this.update();
 
+      const options = this.options();
       const chart = await this.chart();
 
       if (!this.chartCreated) {
@@ -104,7 +105,7 @@ export class HighchartsChartDirective {
           this.chartCreated = true;
         }
       } else {
-        chart?.update(this.options(), true, this.oneToOne());
+        chart?.update(options, true, this.oneToOne());
       }
     });
   }


### PR DESCRIPTION
Fixes #432 

`this.options()` is not tracked in the effect as it isn't called on first run when `chartCreated` is false. By calling it outside of the conditional it will ensure the options signal is tracked and triggers the effect when updated.