### PR TITLE
bugfix/439-instance-export

### DIFF
--- a/highcharts-angular/src/lib/highcharts-chart.directive.ts
+++ b/highcharts-angular/src/lib/highcharts-chart.directive.ts
@@ -80,6 +80,7 @@ export class HighchartsChartDirective {
     await this.delay(this.relativeConfig?.timeout ?? this.timeout ?? 500);
     if (!highCharts) return;
     const callback: Highcharts.ChartCallbackFunction = (chart: Highcharts.Chart) => {
+      if (chart.renderer.forExport) return;
       return this.chartInstance.emit(chart);
     };
     const chartFactories: Record<ChartConstructorType, ConstructorChart> = {


### PR DESCRIPTION
Do not emit chart instance on export, closes #439.